### PR TITLE
Guide to use `--no-verify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 git config core.hooksPath hooks
 ```
 
-Since `pre-commit` validates Terraform styles, syntax at all, there is a flag to bypass them.
+Since the `pre-commit` hook validates Terraform styles, syntax at all, you may want to bypass it sometimes.
 
 ```sh
-BYPASS_PRE_COMMIT="true" git commit
+git --no-verify commit
 ```

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,11 +2,6 @@
 set -e
 
 if command -v terraform > /dev/null; then
-  if [[ "$BYPASS_PRE_COMMIT" = "true" ]]; then
-    echo "info: pre-commit is bypassed." >&2
-    exit 0
-  fi
-
   terraform fmt -check -recursive
 
   PROJECTS=(dx/dx-cluster dx/mimir-main-cluster dx/mimir-internal-cluster)


### PR DESCRIPTION
I realized that `git commit` command provides `--no-verify` option to bypass pre-commit and commit-msg hooks and commit in force. This pull request deprecates `BYPASS_PRE_COMMIT` environment flag and guide to use `--no-verify` option.

https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-verify