### PR TITLE
Apply Sentry-related features for mainnet mimir & mimir-worker

### DIFF
--- a/dx/mimir-main-cluster/mimir-worker.tf
+++ b/dx/mimir-main-cluster/mimir-worker.tf
@@ -22,6 +22,7 @@ module "mimir_worker_odin_diff_ec2" {
     "http://9c-main-rpc-2.nine-chronicles.com/graphql"
   ]
   repository_credentials = var.repository_credentials
+  use_sentry             = true
 }
 
 module "mimir_worker_odin_action_ec2" {
@@ -48,6 +49,7 @@ module "mimir_worker_odin_action_ec2" {
     "http://9c-main-rpc-2.nine-chronicles.com/graphql"
   ]
   repository_credentials = var.repository_credentials
+  use_sentry             = true
 }
 
 module "mimir_worker_heimdall_diff_ec2" {
@@ -74,6 +76,7 @@ module "mimir_worker_heimdall_diff_ec2" {
     "http://heimdall-rpc-2.nine-chronicles.com/graphql"
   ]
   repository_credentials = var.repository_credentials
+  use_sentry             = true
 }
 
 module "mimir_worker_heimdall_action_ec2" {
@@ -100,4 +103,5 @@ module "mimir_worker_heimdall_action_ec2" {
     "http://heimdall-rpc-2.nine-chronicles.com/graphql"
   ]
   repository_credentials = var.repository_credentials
+  use_sentry             = true
 }

--- a/dx/mimir-main-cluster/mimir.tf
+++ b/dx/mimir-main-cluster/mimir.tf
@@ -14,6 +14,7 @@ module "mimir_odin_ec2" {
   network                    = "odin"
   environment                = "prod"
   repository_credentials     = var.repository_credentials
+  use_sentry                 = true
 }
 
 module "mimir_heimdall_ec2" {
@@ -32,4 +33,5 @@ module "mimir_heimdall_ec2" {
   network                    = "heimdall"
   environment                = "prod"
   repository_credentials     = var.repository_credentials
+  use_sentry                 = true
 }

--- a/modules/mimir-ec2/ecs_task.tf
+++ b/modules/mimir-ec2/ecs_task.tf
@@ -55,5 +55,11 @@ locals {
       valueFrom = "${aws_secretsmanager_secret.secret.arn}:mongodb_connection_string::"
     },
   ]
-  secrets = concat(local.jwt_secrets, local.mongodb_secrets)
+  sentry_secrets = var.use_sentry ? [
+    {
+      name      = "Sentry__Dsn",
+      valueFrom = "${aws_secretsmanager_secret.secret.arn}:sentry_dsn::"
+    }
+  ] : []
+  secrets = concat(local.jwt_secrets, local.mongodb_secrets, local.sentry_secrets)
 }

--- a/modules/mimir-ec2/variables.tf
+++ b/modules/mimir-ec2/variables.tf
@@ -81,6 +81,12 @@ variable "use_jwt" {
   default     = true
 }
 
+variable "use_sentry" {
+  description = "Flag to include Sentry related secrets. In other words, it enables Sentry."
+  type        = bool
+  default     = false
+}
+
 locals {
   kebab_case_prefix = "${var.cluster_name}-${var.network}-${var.environment}"
 }

--- a/modules/mimir-worker-ec2/ecs_task.tf
+++ b/modules/mimir-worker-ec2/ecs_task.tf
@@ -44,5 +44,11 @@ locals {
       valueFrom = "${aws_secretsmanager_secret.secret.arn}:mongodb_db_connection_string::"
     }
   ]
-  secrets = concat(local.jwt_secrets, local.mongodb_secrets)
+  sentry_secrets = var.use_sentry ? [
+    {
+      name      = "Sentry__Dsn",
+      valueFrom = "${aws_secretsmanager_secret.secret.arn}:sentry_dsn::"
+    }
+  ] : []
+  secrets = concat(local.jwt_secrets, local.mongodb_secrets, local.sentry_secrets)
 }

--- a/modules/mimir-worker-ec2/variables.tf
+++ b/modules/mimir-worker-ec2/variables.tf
@@ -96,6 +96,12 @@ variable "use_jwt" {
   default     = true
 }
 
+variable "use_sentry" {
+  description = "Flag to include Sentry related secrets. In other words, it enables Sentry."
+  type        = bool
+  default     = false
+}
+
 locals {
   kebab_case_prefix = "${var.cluster_name}-worker-${var.planet_type}-${var.short_poller_type}-${var.environment}"
 }


### PR DESCRIPTION
> [!NOTE]
> #22 must be merged first.

It introduces the `use_sentry: bool' input variable on mimir-ec2 and mimir-worker-ec2 modules. And it enables the flag for resources using those modules in the mainnet.