### PR TITLE
deploy mimir 71a7cf3101622721936dd6626e78a6f2bfdc628f

### DIFF
--- a/dx/mimir-internal-cluster/terraform.public.auto.tfvars
+++ b/dx/mimir-internal-cluster/terraform.public.auto.tfvars
@@ -1,8 +1,8 @@
 cluster_name        = "mimir-itn"
 region              = "us-east-2"
 environment         = "stag"
-mimir_image         = "git-3515b3e5f9b2a37ff4e2c08a2097ab2542a596b2"
-mimir_worker_image  = "git-3515b3e5f9b2a37ff4e2c08a2097ab2542a596b2"
+mimir_image         = "git-71a7cf3101622721936dd6626e78a6f2bfdc628f"
+mimir_worker_image  = "git-71a7cf3101622721936dd6626e78a6f2bfdc628f"
 vpc_cidr_block      = "10.0.0.0/16"
 create_route_tables = true
 create_nat_gateways = true

--- a/dx/mimir-main-cluster/terraform.public.auto.tfvars
+++ b/dx/mimir-main-cluster/terraform.public.auto.tfvars
@@ -1,7 +1,7 @@
 cluster_name        = "mimir-main"
 region              = "us-east-2"
 environment         = "prod"
-mimir_image         = "git-e0291317b355161be2d15e1379b5463c306c4d53"
-mimir_worker_image  = "git-e0291317b355161be2d15e1379b5463c306c4d53"
+mimir_image         = "git-71a7cf3101622721936dd6626e78a6f2bfdc628f"
+mimir_worker_image  = "git-71a7cf3101622721936dd6626e78a6f2bfdc628f"
 vpc_cidr_block      = "10.0.0.0/16"
 create_route_tables = true


### PR DESCRIPTION
deploy mimir `71a7cf3101622721936dd6626e78a6f2bfdc628f` to main and internal.