### PR TITLE
fix: correct sentry-related env

### DIFF
--- a/modules/mimir-worker-ec2/ecs_task.tf
+++ b/modules/mimir-worker-ec2/ecs_task.tf
@@ -46,7 +46,7 @@ locals {
   ]
   sentry_secrets = var.use_sentry ? [
     {
-      name      = "Sentry__Dsn",
+      name      = "WORKER_Configuration__SentryDsn",
       valueFrom = "${aws_secretsmanager_secret.secret.arn}:sentry_dsn::"
     }
   ] : []


### PR DESCRIPTION
According to [mimir code](https://github.com/planetarium/mimir/blob/bb31e73aa15d0e77f5604d5a127b0ce3106927f3/Mimir.Worker/Program.cs#L17-L20), it must pass the value as `Configuration.SentryDsn` (in environment format, `WORKER_Configuration__SentryDsn`)